### PR TITLE
Initial support for a GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Misc
 .irb_history
+.byebug_history
 
 # Editor cruft
 *.swp

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
-gemspec
+# Add any gems that your plugin needs for its development environment only
+gem 'origen_jtag', '>= 0.12.0'
+gem 'origen_doc_helpers'
+gem 'byebug'
+gem 'http'
 
-gem 'byebug', '~>3.5'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     origen_link (0.1.2)
       origen (>= 0.7.2)
       origen_testers (>= 0.6.1)
+      sinatra (~> 1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,6 +15,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
@@ -34,6 +36,8 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     geminabox (0.12.4)
@@ -44,6 +48,15 @@ GEM
       sinatra (>= 1.2.7)
     gems (0.8.3)
     highline (1.7.8)
+    http (2.0.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -64,6 +77,8 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nokogiri (1.6.7.2-x64-mingw32)
+      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x86-mingw32)
       mini_portile2 (~> 2.0.0.rc2)
     origen (0.7.10)
       activesupport (~> 4.1)
@@ -98,7 +113,6 @@ GEM
       require_all (~> 1)
     parser (2.3.1.0)
       ast (~> 2.2)
-    power_assert (0.3.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -144,13 +158,16 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    test-unit (3.1.8)
-      power_assert
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.2-x64-mingw32)
+    unf_ext (0.0.7.2-x86-mingw32)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -159,8 +176,11 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  byebug (~> 3.5)
+  byebug
+  http
   origen_doc_helpers
   origen_jtag (>= 0.12.0)
   origen_link!
-  test-unit
+
+BUNDLED WITH
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     origen_link (0.1.2)
       origen (>= 0.7.2)
       origen_testers (>= 0.6.1)
-      sinatra (~> 1)
+      sinatra (~> 1, >= 1.4.7)
 
 GEM
   remote: https://rubygems.org/
@@ -67,7 +67,7 @@ GEM
     log4r (1.1.10)
     method_source (0.8.2)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nanoc (3.8.0)
@@ -80,7 +80,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     nokogiri (1.6.7.2-x86-mingw32)
       mini_portile2 (~> 2.0.0.rc2)
-    origen (0.7.10)
+    origen (0.7.12)
       activesupport (~> 4.1)
       bundler (~> 1.7)
       coderay (~> 1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,10 @@ class OrigenLinkApplication < Origen::Application
 
   config.semantically_version = true
 
+  config.shared = {
+    command_launcher: 'config/shared_commands.rb'
+  }
+
   # An example of how to set application specific LSF parameters
   #config.lsf.project = "msg.te"
   

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -2,11 +2,31 @@
 case @command
 
 when "link:listen"
-  Origen.target.load!
-  OrigenLink::Listener.run!
-  # Important to exit when a command has been fulfilled or else Origen core will try and execute it
-  exit 0
+  t = Thread.new do
+    OrigenLink::Listener.run!
+  end
+  Thread.new do
+    # Get the current host
+    host = `hostname`.strip.downcase
+    if Origen.os.windows?
+      domain = ''  # Not sure what to do in this case...
+    else
+      domain = `dnsdomainname`.strip
+    end
+    port = 20020
+    puts ''
+    sleep 0.5
+    puts
+    puts
+    puts "*************************************************************"
+    puts "Point your OrigenLink app to:  http://#{host}#{domain.empty? ? '' : '.' + domain}:#{port}"
+    puts "*************************************************************"
+    puts
+    puts
+  end
 
+  # Fall through to the Origen interactive command to open up a console
+  @command = "interactive"
 
 # Always leave an else clause to allow control to fall back through to the Origen command handler.
 # You probably want to also add the command details to the help shown via 'origen -h',
@@ -14,7 +34,7 @@ when "link:listen"
 # Origen.
 else
   @plugin_commands << <<-EOT
- link:listen     Listen for OrigenLink requests over http (from a GUI)
+ link:listen     Open a console and listen for OrigenLink requests over http (i.e. from a GUI)
   EOT
 
 end

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -1,0 +1,20 @@
+# The requested command is passed in here as @command
+case @command
+
+when "link:listen"
+  Origen.target.load!
+  OrigenLink::Listener.run!
+  # Important to exit when a command has been fulfilled or else Origen core will try and execute it
+  exit 0
+
+
+# Always leave an else clause to allow control to fall back through to the Origen command handler.
+# You probably want to also add the command details to the help shown via 'origen -h',
+# you can do this bb adding the required text to @plugin_commands before handing control back to
+# Origen.
+else
+  @plugin_commands << <<-EOT
+ link:listen     Listen for OrigenLink requests over http (from a GUI)
+  EOT
+
+end

--- a/lib/origen_link.rb
+++ b/lib/origen_link.rb
@@ -1,4 +1,4 @@
 require 'origen'
 require 'socket'
-
 require 'origen_link/vector_based'
+require 'origen_link/listener'

--- a/lib/origen_link/listener.rb
+++ b/lib/origen_link/listener.rb
@@ -1,0 +1,60 @@
+require 'sinatra/base'
+module OrigenLink
+  class Listener < Sinatra::Base
+    def self.port
+      @port || 20_020
+    end
+
+    def self.target_object
+      @target_object || dut
+    end
+
+    def self.run!(options = {})
+      @port = options[:port] if options[:port]
+      @target_object = options[:dut]
+      super
+    end
+
+    def target_object
+      self.class.target_object
+    end
+
+    def expand_path(path)
+      path.split('.').each do |p|
+        if p =~ /(.*)\[(\d+)(:(\d+))?\]$/
+          msb = Regexp.last_match(2).to_i
+          lsb = Regexp.last_match(4).to_i if Regexp.last_match(4)
+          yield Regexp.last_match(1)
+          if lsb
+            yield '[]', msb..lsb
+          else
+            yield '[]', msb
+          end
+        else
+          yield p
+        end
+      end
+    end
+
+    get '/hello_world' do
+      'Hello there'
+    end
+
+    get '/dut_class' do
+      target_object.class.to_s
+    end
+
+    post '/write_register' do
+      t = target_object
+      expand_path(params[:path]) do |method, arg|
+        if arg
+          t = t.send(method, arg)
+        else
+          t = t.send(method)
+        end
+      end
+      t.write!(params[:data].to_i)
+      nil
+    end
+  end
+end

--- a/lib/origen_link/listener.rb
+++ b/lib/origen_link/listener.rb
@@ -44,7 +44,7 @@ module OrigenLink
       target_object.class.to_s
     end
 
-    post '/write_register' do
+    post '/register' do
       t = target_object
       expand_path(params[:path]) do |method, arg|
         if arg
@@ -55,6 +55,19 @@ module OrigenLink
       end
       t.write!(params[:data].to_i)
       nil
+    end
+
+    get '/register' do
+      t = target_object
+      expand_path(params[:path]) do |method, arg|
+        if arg
+          t = t.send(method, arg)
+        else
+          t = t.send(method)
+        end
+      end
+      t.sync
+      t.data.to_s
     end
   end
 end

--- a/lib/origen_link/listener.rb
+++ b/lib/origen_link/listener.rb
@@ -5,12 +5,17 @@ module OrigenLink
       @port || 20_020
     end
 
+    def self.environment
+      @environment || :production
+    end
+
     def self.target_object
       @target_object || dut
     end
 
     def self.run!(options = {})
-      @port = options[:port] if options[:port]
+      @port = options[:port]
+      @environment = options[:environment]
       @target_object = options[:dut]
       super
     end

--- a/origen_link.gemspec
+++ b/origen_link.gemspec
@@ -26,9 +26,5 @@ Gem::Specification.new do |spec|
   # Add any gems that your plugin needs to run within a host application
   spec.add_runtime_dependency 'origen', '>= 0.7.2'
   spec.add_runtime_dependency 'origen_testers', '>= 0.6.1'
-    
-  # Add any gems that your plugin needs for its development environment only
-  spec.add_development_dependency 'origen_jtag', '>= 0.12.0'
-  spec.add_development_dependency 'origen_doc_helpers'
-  spec.add_development_dependency 'test-unit'
+  spec.add_runtime_dependency 'sinatra', '~> 1'
 end

--- a/origen_link.gemspec
+++ b/origen_link.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   # Add any gems that your plugin needs to run within a host application
   spec.add_runtime_dependency 'origen', '>= 0.7.2'
   spec.add_runtime_dependency 'origen_testers', '>= 0.6.1'
-  spec.add_runtime_dependency 'sinatra', '~> 1'
+  spec.add_runtime_dependency 'sinatra', '~> 1', '>= 1.4.7'
 end

--- a/spec/listener_spec.rb
+++ b/spec/listener_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'The Link Listener' do
+
+  class LinkListenerTestDUT
+    include Origen::TopLevel
+    attr_accessor :write_requests, :read_requests
+
+    def initialize
+      add_reg :reg1, 0
+      #sub_block :sub
+      @write_requests = 0
+      @read_requests = 0
+
+      sub_block :sub, class_name: 'LinkSubBlock'
+    end
+
+    def write_register(reg, options={})
+      @write_requests += 1
+    end
+
+    def read_register(reg, options={})
+      @read_requests += 1
+    end
+  end
+
+  class LinkSubBlock
+    include Origen::Model
+
+    def initialize
+      add_reg :reg1, 0
+      add_reg :reg2, 0x4 do |reg|
+        reg.bits 31..16, :upper
+        reg.bits 15..0, :lower
+      end
+    end
+  end
+
+  before :all do
+    @thread = Thread.new do
+      OrigenLink::Listener.run!(port: 12345)
+    end
+    sleep 0.2
+
+    Origen.target.temporary = -> { LinkListenerTestDUT.new }
+    Origen.target.load!
+  end
+
+  after :all do
+    @thread.kill
+  end
+
+  it 'is alive' do
+    r = HTTP.get("http://localhost:12345/hello_world")
+    r.code.should == 200
+    r.body.to_s.should == "Hello there"
+  end
+
+  it 'can see the DUT' do
+    r = HTTP.get("http://localhost:12345/dut_class")
+    r.code.should == 200
+    r.body.to_s.should == "LinkListenerTestDUT"
+  end
+
+  it 'registers can be written' do
+    dut.reg1.data.should == 0
+    dut.write_requests.should == 0
+    r = HTTP.post("http://localhost:12345/write_register", form: {path: 'reg1', data: 0xFFFF_FFFF})
+    r.code.should == 200
+    dut.reg1.data.should == 0xFFFF_FFFF
+    r = HTTP.post("http://localhost:12345/write_register", form: {path: 'sub.reg1', data: 0xFF})
+    r.code.should == 200
+    dut.sub.reg1.data.should == 0xFF
+    r = HTTP.post("http://localhost:12345/write_register", form: {path: 'sub.reg2.upper', data: 0x55})
+    r.code.should == 200
+    dut.sub.reg2.data.should == 0x55_0000
+    r = HTTP.post("http://localhost:12345/write_register", form: {path: 'sub.reg2[7:4]', data: 0xA})
+    r.code.should == 200
+    dut.sub.reg2.data.should == 0x55_00A0
+    r = HTTP.post("http://localhost:12345/write_register", form: {path: 'sub.reg2[3]', data: 1})
+    r.code.should == 200
+    dut.sub.reg2.data.should == 0x55_00A8
+
+    dut.write_requests.should == 5
+  end
+
+  it 'registers can be read'
+end


### PR DESCRIPTION
This PR adds the following command to any app that includes OrigenLink:

``` text
origen link:listen
```

This will start an http server process that will listen on port 20020 for register read and write requests.

These requests will be despatched to the DUT by the Origen app (via an OrigenLink compatible tester that would be loaded by the app's target as normal), and in the case of a read request the data will be returned to the caller.

The intended use case is to allow GUI front ends to be developed for Link, to allow non-TEs, e.g. designers, to interact with the DUT from the comfort of their own desk.

The first GUI will be the made by adding a javascript app to the Origen register maps ([like this](http://origen-sdk.org/link_demo/models/linkdemo_toplevel/adc/)), basically making the register documentation an interface to the live DUT. The javascript app will communicate with the Origen app over this API.

For now, see spec/listener_spec.rb for the API.
