### PR TITLE
Simplification

### DIFF
--- a/lib/origen_link/configuration_commands.rb
+++ b/lib/origen_link/configuration_commands.rb
@@ -37,9 +37,18 @@ module OrigenLink
     #   and pass it to pinorder=
     def set_pinorder
       pinlist = ''
-      Origen.app.pin_pattern_order.each do |pin|
-        pinlist = pinlist + ',' unless pinlist.length == 0
-        pinlist = pinlist + pin.to_s unless pin.is_a?(Hash)
+      ordered_pins_cache.each do |pin|
+        unless pin.is_a?(Hash)
+          if pin.size == 1
+            pinlist = pinlist + ',' unless pinlist.length == 0
+            pinlist = pinlist + pin.name.to_s
+          else
+            dut.pins(pin.id).map.each do |sub_pin|
+              pinlist = pinlist + ',' unless pinlist.length == 0
+              pinlist = pinlist + sub_pin.name.to_s
+            end
+          end
+        end
       end
       self.pinorder = pinlist
     end

--- a/lib/origen_link/configuration_commands.rb
+++ b/lib/origen_link/configuration_commands.rb
@@ -29,6 +29,21 @@ module OrigenLink
       setup_cmd_response_logger('pin_patternorder', response)
     end
 
+    # set_pinorder
+    #   This method is called if the app has not explicitly set the pin order
+    #   for the Link server using pinorder= (above)
+    #
+    #   Origen.app.pin_pattern_order is read to get the pin pattern order
+    #   and pass it to pinorder=
+    def set_pinorder
+      pinlist = ''
+      Origen.app.pin_pattern_order.each do |pin|
+        pinlist = pinlist + ',' unless pinlist.length == 0
+        pinlist = pinlist + pin.to_s unless pin.is_a?(Hash)
+      end
+      self.pinorder = pinlist
+    end
+
     # pinformat=
     #   This method is used to setup the pin clock format on the debugger device.
     #   The supported formats are rl and rh

--- a/lib/origen_link/vector_based.rb
+++ b/lib/origen_link/vector_based.rb
@@ -72,6 +72,7 @@ module OrigenLink
       @pattern_comments = {}
       @user_name = Etc.getlogin
       @initial_comm_sent = false
+      @pinorder = ''
     end
 
     # push_comment
@@ -95,11 +96,12 @@ module OrigenLink
     # push_vector
     #   This method intercepts vector data from Origen, removes white spaces and compresses repeats
     def push_vector(options)
+      set_pinorder if @pinorder == ''
       programmed_data = options[:pin_vals].gsub(/\s+/, '')
       unless options[:timeset]
         puts 'No timeset defined!'
         puts 'Add one to your top level startup method or target like this:'
-        puts '$tester.set_timeset("nvmbist", 40)   # Where 40 is the period in ns'
+        puts 'tester.set_timeset("nvmbist", 40)   # Where 40 is the period in ns'
         exit 1
       end
       tset = options[:timeset].name

--- a/spec/pinorder_spec.rb
+++ b/spec/pinorder_spec.rb
@@ -15,16 +15,34 @@ describe OrigenLink::VectorBased do
     end
   end
 
-  before :all do
-    Origen.target.temporary = -> { PinOrderTestDUT.new ;OrigenLink::Test::VectorBased.new('localhost', 12_777) }
-    Origen.target.load!
+  class PinOrderTestDUT_only
+    include Origen::TopLevel
+
+    def initialize
+      add_pin :tclk
+      add_pin :tdo
+      add_pin :tms
+      add_pin :port_a, size: 8
+      
+      pin_pattern_order :tms, :tdo, :tclk, only: true
+    end
   end
 
   specify "auto setup pin order" do
+    Origen.target.temporary = -> { PinOrderTestDUT.new ;OrigenLink::Test::VectorBased.new('localhost', 12_777) }
+    Origen.target.load!
     tester.pinmap = 'tck, 5, tdo, 8, tms, 10, tdi, 15'
-    tester.message.should == 'pin_assign:tck,5,tdo,8,tms,10,tdi,15'
     tester.set_timeset("nvmbist", 40)
     tester.cycle
-    tester.message.should == 'pin_patternorder:tms,port_a,tdo,tclk'
+    tester.message.should == 'pin_patternorder:tms,port_a7,port_a6,port_a5,port_a4,port_a3,port_a2,port_a1,port_a0,tdo,tclk'
+  end
+
+  specify "auto setup pin order with only true" do
+    Origen.target.temporary = -> { PinOrderTestDUT_only.new ;OrigenLink::Test::VectorBased.new('localhost', 12_777) }
+    Origen.target.load!
+    tester.pinmap = 'tck, 5, tdo, 8, tms, 10, tdi, 15'
+    tester.set_timeset("nvmbist", 40)
+    tester.cycle
+    tester.message.should == 'pin_patternorder:tms,tdo,tclk'
   end
 end

--- a/spec/pinorder_spec.rb
+++ b/spec/pinorder_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe OrigenLink::VectorBased do
+
+  class PinOrderTestDUT
+    include Origen::TopLevel
+
+    def initialize
+      add_pin :tclk
+      add_pin :tdo
+      add_pin :tms
+      add_pin :port_a, size: 8
+      
+      pin_pattern_order :tms, :port_a, :tdo, :tclk
+    end
+  end
+
+  before :all do
+    Origen.target.temporary = -> { PinOrderTestDUT.new ;OrigenLink::Test::VectorBased.new('localhost', 12_777) }
+    Origen.target.load!
+  end
+
+  specify "auto setup pin order" do
+    tester.pinmap = 'tck, 5, tdo, 8, tms, 10, tdi, 15'
+    tester.message.should == 'pin_assign:tck,5,tdo,8,tms,10,tdi,15'
+    tester.set_timeset("nvmbist", 40)
+    tester.cycle
+    tester.message.should == 'pin_patternorder:tms,port_a,tdo,tclk'
+  end
+end


### PR DESCRIPTION
This update is to free the user app from the requirement explicitly setting the Link pin order using:
~~~ruby
  tester.pinorder='tck,tdo,tms,others,blah'
~~~
Existing apps will function the same with no need for update.  The above pin order statement can be excluded.  If it is excluded the Link plug-in will retrieve the pin_order_cache (which is part of the base class for vector based testers), create the Link pin order string, and pass it to the server.