### PR TITLE
always generate at least 1 cycle before a wait

### DIFF
--- a/lib/origen_link/vector_based.rb
+++ b/lib/origen_link/vector_based.rb
@@ -516,6 +516,8 @@ module OrigenLink
         end
         cycle(options)
       else
+        # ensure at least 1 cycle is generated so that pin changes always get applied before the wait
+        cycle
         synchronize			# ensure all generated cycles are executed before delay is run
         sleep time_delay
       end


### PR DESCRIPTION
This will ensure that any pin updates get applied to vector data and run on the DUT before the fixed delay is executed.